### PR TITLE
Added second FillClassProperties method tree

### DIFF
--- a/UmbracoVault/IUmbracoContext.cs
+++ b/UmbracoVault/IUmbracoContext.cs
@@ -123,6 +123,13 @@ namespace UmbracoVault
         /// <param name="getPropertyValue">A func that, provided a property alias and a boolean to indicate recursion, will return a raw value to be processed by the TypeHandler system</param>
         void FillClassProperties<T>(T instance, Func<string, bool, object> getPropertyValue);
 
+        /// <summary>
+        /// Fills out class properties based on a provided, instantiated class and a Func instructing it how to get the raw property data based on alias.
+        /// This allows the TypeHandler system to be used by related classes.
+        /// </summary>
+        /// <typeparam name="T">Type of instantiated class</typeparam>
+        /// <param name="instance">An newed-up instance of T</param>
+        /// <param name="getPropertyValue">A func that, provided a property alias, a Property Info, and a boolean to indicate recursion, will return a raw value to be processed by the TypeHandler system</param>
         void FillClassProperties<T>(T instance, Func<string, PropertyInfo, bool, object> getPropertyValue);
 
         /// <summary>
@@ -134,6 +141,13 @@ namespace UmbracoVault
         /// <returns>True if able to resolve value, false if not</returns>
         bool TryGetValueForProperty(Func<string, bool, object> getPropertyValue, PropertyInfo propertyInfo, out object value);
 
+        /// <summary>
+        /// Uses Vault context to try to resolve value for a single property
+        /// </summary>
+        /// <param name="getPropertyValue">Func to return raw value for the property</param>
+        /// <param name="propertyInfo">Property for which to return a value</param>
+        /// <param name="value">If found value will be set</param>
+        /// <returns>True if able to resolve value, false if not</returns>
         bool TryGetValueForProperty(Func<string, PropertyInfo, bool, object> getPropertyValue, PropertyInfo propertyInfo, out object value);
 
         /// <summary>

--- a/UmbracoVault/UmbracoContext.cs
+++ b/UmbracoVault/UmbracoContext.cs
@@ -259,6 +259,12 @@ namespace UmbracoVault
             }
         }
 
+        /// <summary>
+        /// Fills out class properties based on a provided, instantiated class and a Func instructing it how to get the raw property data based on alias
+        /// </summary>
+        /// <typeparam name="T">Type of instantiated class</typeparam>
+        /// <param name="instance">An newed-up instance of T</param>
+        /// <param name="getPropertyValue">A func that, provided a property alias, a PropertyInfo, and a recursion indicator, will return a raw value to be processed by the TypeHandler system</param>
         public void FillClassProperties<T>(T instance, Func<string, PropertyInfo, bool, object> getPropertyValue)
         {
             var properties = ClassConstructor.GetPropertiesToFill<T>();


### PR DESCRIPTION
- Keeps previous FillClassProperties method infrastructure to facilitate backwards compatibility 
- Added new methods to allow users to provide a PropertyInfo within the FillClassProperties func
- Refactored code within the UmbracoContext method to share as much logic as possible between these methods
