### PR TITLE
fix GetUmbracoEntityAliasesFromType to not return duplicate results

### DIFF
--- a/UmbracoVault.Tests/Models/ExampleRecursiveAttributesViewModel.cs
+++ b/UmbracoVault.Tests/Models/ExampleRecursiveAttributesViewModel.cs
@@ -1,0 +1,14 @@
+﻿using UmbracoVault.Attributes;
+
+namespace UmbracoVault.Tests.Models
+{
+    [UmbracoEntity(AutoMap = true)]
+    public class ExampleRecursiveAttributesViewModel : BaseRecursiveAttributesViewModel
+    {
+    }
+
+    [UmbracoEntity(AutoMap = true)]
+    public class BaseRecursiveAttributesViewModel
+    {
+    }
+}

--- a/UmbracoVault.Tests/UmbracoContextTests.cs
+++ b/UmbracoVault.Tests/UmbracoContextTests.cs
@@ -196,6 +196,13 @@ namespace UmbracoVault.Tests
             {
                 Assert.AreEqual(Source.ExampleEnum, Destination.ExampleEnum);
             }
+
+            [TestMethod]
+            public void GetUmbracoEntityAliasesFromType_ShouldBeDistinct()
+            {
+                var aliases = UmbracoWebContext.GetUmbracoEntityAliasesFromType(typeof(ExampleRecursiveAttributesViewModel)).OrderBy(x => x);
+                Assert.IsTrue(aliases.SequenceEqual(aliases.Distinct()));
+            }
         }
     }
 }

--- a/UmbracoVault.Tests/UmbracoVault.Tests.csproj
+++ b/UmbracoVault.Tests/UmbracoVault.Tests.csproj
@@ -65,6 +65,7 @@
   <ItemGroup>
     <Compile Include="DefaultInstanceFactoryTests.cs" />
     <Compile Include="Models\AutoRegisteredTypeHandler.cs" />
+    <Compile Include="Models\ExampleRecursiveAttributesViewModel.cs" />
     <Compile Include="Models\IgnoredTypeHandler.cs" />
     <Compile Include="Models\CustomTypeHandler.cs" />
     <Compile Include="Models\ExampleEnum.cs" />

--- a/UmbracoVault/UmbracoContext.cs
+++ b/UmbracoVault/UmbracoContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
@@ -470,7 +470,7 @@ namespace UmbracoVault
             return result;
         }
 
-        private static ReadOnlyCollection<string> GetUmbracoEntityAliasesFromType(Type type)
+        public static ReadOnlyCollection<string> GetUmbracoEntityAliasesFromType(Type type)
         {
             var results = new List<string>();
             var attributes = type.GetUmbracoEntityAttributes().ToList();

--- a/UmbracoVault/UmbracoContext.cs
+++ b/UmbracoVault/UmbracoContext.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
@@ -472,7 +472,7 @@ namespace UmbracoVault
 
         public static ReadOnlyCollection<string> GetUmbracoEntityAliasesFromType(Type type)
         {
-            var results = new List<string>();
+            var results = new HashSet<string>();
             var attributes = type.GetUmbracoEntityAttributes().ToList();
             if (attributes.Any())
             {
@@ -488,7 +488,7 @@ namespace UmbracoVault
                 }
             }
 
-            return results.AsReadOnly();
+            return results.ToList().AsReadOnly();
         }
     }
 }


### PR DESCRIPTION
this fixes a bug that was causing `GetByDocumentType` to return duplicate umbraco content for each instance of UmbracoEntityAttribute found in the inheritance hierarchy because each one resolved to the same type name and alias