### PR TITLE
Allows for the ability to strongly-type a list of child items

### DIFF
--- a/UmbracoVault/Attributes/UmbracoEntityAttribute.cs
+++ b/UmbracoVault/Attributes/UmbracoEntityAttribute.cs
@@ -12,7 +12,8 @@ namespace UmbracoVault.Attributes
 	{
 		public UmbracoEntityAttribute()
 		{
-		}
+            ReturnStronglyTypedChildren = true;
+        }
 
 		/// <summary>
 		/// Only needed if the name of the Entity is not the same as the umbraco Doc Type alias
@@ -21,7 +22,8 @@ namespace UmbracoVault.Attributes
 		public UmbracoEntityAttribute(string alias)
 		{
 			Alias = alias;
-		}
+            ReturnStronglyTypedChildren = true;
+        }
 
         /// <summary>
         /// When false (default), you must manually opt in all properties to be mapped with the [UmbracoProperty] attribute.
@@ -39,5 +41,7 @@ namespace UmbracoVault.Attributes
         /// Typehandler must implement ITypeHandler
         /// </summary>
         public virtual Type TypeHandlerOverride { get; set; }
-	}
+
+        public bool ReturnStronglyTypedChildren { get; set; }
+    }
 }

--- a/UmbracoVault/Base/BaseUmbracoContext.cs
+++ b/UmbracoVault/Base/BaseUmbracoContext.cs
@@ -9,6 +9,7 @@ using Umbraco.Core.Models;
 using UmbracoVault.Attributes;
 using UmbracoVault.Caching;
 using UmbracoVault.Extensions;
+using UmbracoVault.Models;
 using UmbracoVault.TypeHandlers;
 
 
@@ -19,6 +20,24 @@ namespace UmbracoVault
     {
         protected readonly TypeHandlerFactory _typeHandlerFactory;
         protected readonly CacheManager _cacheManager;
+
+        private static List<VaultEntity> _vaultEntities;
+
+        internal List<VaultEntity> VaultEntities
+        {
+            get
+            {
+                if (_vaultEntities == null)
+                {
+                    _vaultEntities = VaultEntityExtensions.GetValutEntities();
+                }
+                return _vaultEntities;
+            }
+            set
+            {
+                _vaultEntities = value;
+            }
+        }
 
         protected BaseUmbracoContext()
         {

--- a/UmbracoVault/Extensions/VaultEntityExtensions.cs
+++ b/UmbracoVault/Extensions/VaultEntityExtensions.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UmbracoVault.Attributes;
+using UmbracoVault.Models;
+
+namespace UmbracoVault.Extensions
+{
+    internal static class VaultEntityExtensions
+    {
+        private static List<VaultEntity> _entities;
+        private static readonly object Padlock = new object();
+
+        internal static List<VaultEntity> GetValutEntities()
+        {
+            if (_entities == null)
+            {
+                lock (Padlock)
+                {
+                    if (_entities == null)
+                    {
+                        _entities = LoadVaultEntities();
+                    }
+                }
+            }
+
+            return _entities;
+        }
+
+        private static List<VaultEntity> LoadVaultEntities()
+        {
+            var output = AppDomain.CurrentDomain.GetAssemblies()
+                        .SelectMany(
+                        x =>
+                        {
+                            Type[] types;
+                            try
+                            {
+                                types = x.GetTypes();
+                            }
+                            // TODO: We may need to create a fluent registration system for these viewmodels.
+                            catch (Exception) // TODO: Generic exception says 'whaa!?'
+                            {
+                                return new Type[] { };
+                            }
+                            return types;
+                        })
+                        .Select(x =>
+                        {
+                            try
+                            {
+                                return new VaultEntity
+                                {
+                                    MetaData = ((UmbracoEntityAttribute)Attribute.GetCustomAttribute(x, typeof(UmbracoEntityAttribute), false)),
+                                    Type = x
+
+                                };
+                            }
+                            catch (TypeLoadException) // Ignore type loads
+                            {
+                                return new VaultEntity();
+                            }
+                        })
+                        .Where(x => x.MetaData != null)
+                        .ToList();
+
+            return output;
+        }
+    }
+}

--- a/UmbracoVault/Models/VaultEntity.cs
+++ b/UmbracoVault/Models/VaultEntity.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using UmbracoVault.Attributes;
+
+namespace UmbracoVault.Models
+{
+    internal class VaultEntity
+    {
+        public UmbracoEntityAttribute MetaData { get; set; }
+        public Type Type { get; set; }
+    }
+}

--- a/UmbracoVault/UmbracoVault.csproj
+++ b/UmbracoVault/UmbracoVault.csproj
@@ -88,7 +88,9 @@
     <Compile Include="Controllers\VaultRenderMvcController.cs" />
     <Compile Include="Exceptions\VaultNotImplementedException.cs" />
     <Compile Include="Extensions\ObjectExtensions.cs" />
+    <Compile Include="Extensions\VaultEntityExtensions.cs" />
     <Compile Include="Models\NamedItem.cs" />
+    <Compile Include="Models\VaultEntity.cs" />
     <Compile Include="Proxy\ILazyResolverMixin.cs" />
     <Compile Include="Proxy\LazyContentResolverMixin.cs" />
     <Compile Include="Proxy\LazyResolverMixin.cs" />


### PR DESCRIPTION
# Summary
Incorporated changes from an old Vault fork that allows for querying strongly-typed children based upon a base type.

# Example
```csharp

[UmbracoEntity]
public abstract class BaseItem
{
     public string Title { get; set;}
}

[UmbracoEntity]
public class RangeItem : BaseItem
{
     public int Start { get; set; }
     public int Stop { get; set; }
} 

[UmbracoEntity]
public class SpecialItem : BaseItem
{
     public string LookAtMeIAmSpecial { get; set; }
}

var children = Vault.Context.GetChildren<BaseItem>(0);

```

The **children** variable in this instance will then contain an array of either strongly-typed Range or Special Items, as determined by the individual item's Alias/DocType.

# Reference 
See feature request #22 

# Notes
- There are some potentially bad practices in this code we may want to re-design, such as scanning all assemblies for all classes with an UmbracoEntity attribute.