### PR TITLE
Thread Safe Proxy Cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## v1.2.3
- * Fixes an issue where high amount of concurrent threads would cause multiple entries with same key to proxy property cache [#31]
+ * Fixes an issue where high amount of concurrent threads would cause multiple entries with same key to proxy property cache
 
 ## v1.2.2
  * Fixes an issue where models implementing an interface would not properly have their values set [#29]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.2.3
+ * Fixes an issue where high amount of concurrent threads would cause multiple entries with same key to proxy property cache [#31]
+
 ## v1.2.2
  * Fixes an issue where models implementing an interface would not properly have their values set [#29]
  * Fixes an issue where explicit interface implementations would not properly have their values set [#29]

--- a/UmbracoVault/UmbracoVault.nuspec
+++ b/UmbracoVault/UmbracoVault.nuspec
@@ -11,7 +11,8 @@
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <description>Vault for Umbraco is an easy-to-use, extensible ORM to quickly and easily get strongly-typed Umbraco CMS data into your views. It allows you to create lightly-decorated classes that Vault will understand how to hydrate. This gives you the full view model-style experience in Umbraco that you are accustomed to in MVC, complete with strongly-typed view properties (no more magic strings in your views).</description>
         <summary>Vault for Umbraco is an easy-to-use, extensible ORM to quickly and easily get strongly-typed Umbraco CMS data into your views.</summary>
-        <releaseNotes> * Fixes an issue where models implementing an interface would not properly have their values set [#29]
+        <releaseNotes> *Fixes issue where high concurrency causes multiple cache entries with same key
+        * Fixes an issue where models implementing an interface would not properly have their values set [#29]
  * Fixes an issue where explicit interface implementations would not properly have their values set [#29]
           </releaseNotes>
       <copyright>(c) The Nerdery LLC 2016. All Rights Reserved.</copyright>

--- a/UmbracoVault/UmbracoVault.nuspec
+++ b/UmbracoVault/UmbracoVault.nuspec
@@ -11,10 +11,7 @@
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <description>Vault for Umbraco is an easy-to-use, extensible ORM to quickly and easily get strongly-typed Umbraco CMS data into your views. It allows you to create lightly-decorated classes that Vault will understand how to hydrate. This gives you the full view model-style experience in Umbraco that you are accustomed to in MVC, complete with strongly-typed view properties (no more magic strings in your views).</description>
         <summary>Vault for Umbraco is an easy-to-use, extensible ORM to quickly and easily get strongly-typed Umbraco CMS data into your views.</summary>
-        <releaseNotes> *Fixes issue where high concurrency causes multiple cache entries with same key
-        * Fixes an issue where models implementing an interface would not properly have their values set [#29]
- * Fixes an issue where explicit interface implementations would not properly have their values set [#29]
-          </releaseNotes>
+        <releaseNotes> *Fixes issue where high concurrency causes multiple cache entries with same key</releaseNotes>
       <copyright>(c) The Nerdery LLC 2016. All Rights Reserved.</copyright>
       <tags>Umbraco UmbracoVault Mapping ObjectMapper ORM CMS</tags>
         <dependencies>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
-  CURRENT_VERSION: 1.2.2
-version: 1.2.2-{build}
+  CURRENT_VERSION: 1.2.3
+version: 1.2.3-{build}
 os: Visual Studio 2015
 assembly_info:
   patch: true


### PR DESCRIPTION
Under heavy traffic, occasionally the Proxy "LazyResolverMixin" would attempt to add the same key to the property value cache. This updates the method to attempt to retrieve value, if failed, locks, rechecks, and finally adds value to cache.