### PR TITLE
Updates GetCurrent to use IPublishedContent on the request rather than by looking up by id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.3.2
+
+* Updates UmbracoWebContext.GetCurrent to use the PublishedContent from the PublishedContentRequest rather than getting a page by the current id. 
+
 ## v1.3.1
 
 * Fixes issue where proxied models created from IContent models did not support recursive hydration.

--- a/UmbracoVault/UmbracoContext.cs
+++ b/UmbracoVault/UmbracoContext.cs
@@ -55,7 +55,7 @@ namespace UmbracoVault
         public override T GetCurrent<T>()
         {
             var umbracoItem = GetCurrentUmbracoContent();
-            if (umbracoItem == null || umbracoItem.Id <= 0)
+            if (umbracoItem == null)
             {
                 LogHelper.Error<T>("Could not retrieve current umbraco item.", null);
                 return default(T);

--- a/UmbracoVault/UmbracoContext.cs
+++ b/UmbracoVault/UmbracoContext.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Reflection;
 using System.Web;
 
 using Umbraco.Core;
@@ -33,9 +34,9 @@ namespace UmbracoVault
 
         private IPublishedContent GetCurrentUmbracoContent()
         {
-            if (UmbracoContext.Current.PageId != null)
+            if (UmbracoContext.Current.PublishedContentRequest.HasPublishedContent)
             {
-                return GetUmbracoContent(UmbracoContext.Current.PageId.Value);
+                return UmbracoContext.Current.PublishedContentRequest.PublishedContent;
             }
             return null;
         }
@@ -74,9 +75,8 @@ namespace UmbracoVault
         /// <returns>A fully-hydrated type (as defined by the Type parameter) containing data mapped from the current umbraco item</returns>
         public override object GetCurrent(Type type)
         {
-            // ReSharper disable once PossibleInvalidOperationException
-            var id = UmbracoContext.Current.PageId.Value;
-            return GetContentById(type, id.ToString());
+            var methodInfo = GetType().GetMethod(nameof(GetCurrent), new Type[0]);
+            return methodInfo.MakeGenericMethod(type).Invoke(this, null);
         }
 
         public override T GetContentById<T>(int id)

--- a/UmbracoVault/UmbracoVault.nuspec
+++ b/UmbracoVault/UmbracoVault.nuspec
@@ -12,9 +12,7 @@
         <description>Vault for Umbraco is an easy-to-use, extensible ORM to quickly and easily get strongly-typed Umbraco CMS data into your views. It allows you to create lightly-decorated classes that Vault will understand how to hydrate. This gives you the full view model-style experience in Umbraco that you are accustomed to in MVC, complete with strongly-typed view properties (no more magic strings in your views).</description>
         <summary>Vault for Umbraco is an easy-to-use, extensible ORM to quickly and easily get strongly-typed Umbraco CMS data into your views.</summary>
         <releaseNotes>
-          * Fixes issue where proxied models created from IContent models did not support recursive hydration.
-          * Fixes issue where if a proxy property was overwritten with some value not from CMS, it would not persist and would still use CMS value.
-          * Fixes issue where preview content breaks due to use of a singleton UmbracoHelper. [#34]
+          * Updates UmbracoWebContext.GetCurrent to use the PublishedContent from the PublishedContentRequest rather than getting a page by the current id. 
         </releaseNotes>
       <copyright>(c) The Nerdery LLC 2016. All Rights Reserved.</copyright>
       <tags>Umbraco UmbracoVault Mapping ObjectMapper ORM CMS</tags>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
-  CURRENT_VERSION: 1.3.1
-version: 1.3.1-{build}
+  CURRENT_VERSION: 1.3.2
+version: 1.3.2-{build}
 os: Visual Studio 2015
 assembly_info:
   patch: true


### PR DESCRIPTION
I updated the UmbracoWebContext.GetCurrent methods to use the IPublishedContent from the UmbracoContext.Current.PublishedContentRequest rather than using the page id for mapping. This will support pages that use virtual pages which attach virtual content that implements IPublishedContent but are not real Umbraco pages (for example, e-commerce products). This should also be marginally faster than doing an additional lookup.

@NerderyMGlanzer I assigned to you because I know you've spent some time in the source code and Ken isn't around anymore. Let me know what you think.