### PR TITLE
Updates value transformation process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.3.2
 
 * Updates UmbracoWebContext.GetCurrent to use the PublishedContent from the PublishedContentRequest rather than getting a page by the current id. 
+* Updated value transformation process to execute type handler even if value type already matches target type to ensure all proper transforms are applied.
 
 ## v1.3.1
 

--- a/UmbracoVault.Tests/Attributes/TrimStringPropertyAttribute.cs
+++ b/UmbracoVault.Tests/Attributes/TrimStringPropertyAttribute.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using UmbracoVault.Attributes;
+using UmbracoVault.Tests.Handlers;
+
+namespace UmbracoVault.Tests.Attributes
+{
+    public class TrimStringPropertyAttribute : UmbracoPropertyAttribute
+    {
+        public TrimStringPropertyAttribute()
+        {
+            TypeHandler = new TrimStringTypeHandler();
+        }
+
+        public TrimStringPropertyAttribute(string alias) : base(alias)
+        {
+            TypeHandler = new TrimStringTypeHandler();
+        }
+    }
+}

--- a/UmbracoVault.Tests/Handlers/TrimStringTypeHandler.cs
+++ b/UmbracoVault.Tests/Handlers/TrimStringTypeHandler.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using UmbracoVault.TypeHandlers;
+
+namespace UmbracoVault.Tests.Handlers
+{
+    class TrimStringTypeHandler : ITypeHandler
+    {
+        public object GetAsType<T>(object input)
+        {
+            return input?.ToString()?.Trim();
+        }
+
+        public Type TypeSupported => typeof(string);
+    }
+}

--- a/UmbracoVault.Tests/Models/ExampleModelAllTypes.cs
+++ b/UmbracoVault.Tests/Models/ExampleModelAllTypes.cs
@@ -1,4 +1,5 @@
 ﻿using UmbracoVault.Attributes;
+using UmbracoVault.Tests.Attributes;
 
 namespace UmbracoVault.Tests.Models
 {
@@ -57,5 +58,8 @@ namespace UmbracoVault.Tests.Models
 
         [UmbracoEnumProperty]
         public ExampleEnum ExampleEnum { get; set; }
+
+        [TrimStringProperty]
+        public string TypeHandledString { get; set; }
     }
 }

--- a/UmbracoVault.Tests/UmbracoContextTests.cs
+++ b/UmbracoVault.Tests/UmbracoContextTests.cs
@@ -31,6 +31,7 @@ namespace UmbracoVault.Tests
                 Source.StringArray = new[] {"100", "200", "300"};
                 Source.Object = new { Name = "TestObject" };
                 Source.ExampleEnum = ExampleEnum.Harry;
+                Source.TypeHandledString = "       this string needs to be trimmed        ";
 
                 var specialCases = new NameValueCollection
                 {
@@ -168,6 +169,12 @@ namespace UmbracoVault.Tests
             {
                 Assert.AreNotEqual(Destination.String, default(string));
                 Assert.AreEqual(Source.String, Destination.String);
+            }
+
+            [TestMethod]
+            public void TypeHandler_ShouldExecute_EvenWhenTypesAlreadyMatch()
+            {
+                Assert.AreEqual(Source.TypeHandledString.Trim(), Destination.TypeHandledString);
             }
 
             [TestMethod]

--- a/UmbracoVault.Tests/UmbracoVault.Tests.csproj
+++ b/UmbracoVault.Tests/UmbracoVault.Tests.csproj
@@ -63,7 +63,9 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="Attributes\TrimStringPropertyAttribute.cs" />
     <Compile Include="DefaultInstanceFactoryTests.cs" />
+    <Compile Include="Handlers\TrimStringTypeHandler.cs" />
     <Compile Include="ProxyInstanceInterfaceFactoryTests.cs" />
     <Compile Include="DefaultInstanceInterfaceFactoryTests.cs" />
     <Compile Include="Models\AutoRegisteredTypeHandler.cs" />

--- a/UmbracoVault/UmbracoVault.nuspec
+++ b/UmbracoVault/UmbracoVault.nuspec
@@ -13,6 +13,7 @@
         <summary>Vault for Umbraco is an easy-to-use, extensible ORM to quickly and easily get strongly-typed Umbraco CMS data into your views.</summary>
         <releaseNotes>
           * Updates UmbracoWebContext.GetCurrent to use the PublishedContent from the PublishedContentRequest rather than getting a page by the current id. 
+          * Updated value transformation process to execute type handler even if value type already matches target type to ensure all proper transforms are applied.
         </releaseNotes>
       <copyright>(c) The Nerdery LLC 2016. All Rights Reserved.</copyright>
       <tags>Umbraco UmbracoVault Mapping ObjectMapper ORM CMS</tags>


### PR DESCRIPTION
The value was always being returned right away when the value type and target type matched, which was normally fine, but didn't work well on native types that required more transformation (ex. a string). This update allows type handler to execute on value even if the value type and target type match.
