### PR TITLE
Updates UmbracoWebContext.GetChildren to ignore case on document type alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.3.4
+* Updates UmbracoWebContext.GetChildren to ignore case when comparing document type alias with a VM's entity name
+
 ## v1.3.3
 * Updates MediaTypeHandler to return null if no media is found rather than returning an object with all null properties
 

--- a/UmbracoVault/UmbracoContext.cs
+++ b/UmbracoVault/UmbracoContext.cs
@@ -131,7 +131,7 @@ namespace UmbracoVault
 
             var type = typeof(T);
             var aliases = GetUmbracoEntityAliasesFromType(type);
-            var nodes = parentNode.Children.Where(c => aliases.Contains(c.DocumentTypeAlias));
+            var nodes = parentNode.Children.Where(c => aliases.Contains(c.DocumentTypeAlias, StringComparer.InvariantCultureIgnoreCase));
             return nodes.Select(GetItem<T>);
         }
 

--- a/UmbracoVault/UmbracoVault.nuspec
+++ b/UmbracoVault/UmbracoVault.nuspec
@@ -12,7 +12,7 @@
         <description>Vault for Umbraco is an easy-to-use, extensible ORM to quickly and easily get strongly-typed Umbraco CMS data into your views. It allows you to create lightly-decorated classes that Vault will understand how to hydrate. This gives you the full view model-style experience in Umbraco that you are accustomed to in MVC, complete with strongly-typed view properties (no more magic strings in your views).</description>
         <summary>Vault for Umbraco is an easy-to-use, extensible ORM to quickly and easily get strongly-typed Umbraco CMS data into your views.</summary>
         <releaseNotes>
-          * Updates MediaTypeHandler to return null if no media is found rather than returning an object with all null properties
+          * Updates UmbracoWebContext.GetChildren to ignore case when comparing document type alias with a VM's entity name
         </releaseNotes>
       <copyright>(c) The Nerdery LLC 2016. All Rights Reserved.</copyright>
       <tags>Umbraco UmbracoVault Mapping ObjectMapper ORM CMS</tags>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
-  CURRENT_VERSION: 1.3.3
-version: 1.3.3-{build}
+  CURRENT_VERSION: 1.3.4
+version: 1.3.4-{build}
 os: Visual Studio 2015
 assembly_info:
   patch: true


### PR DESCRIPTION
updated UmbracoWebContext.GetChildren to ignore case when comparing document type alias with a VM's entity name