### PR TITLE
Check value input before performing type transformations

### DIFF
--- a/UmbracoVault/TypeHandlers/MediaTypeHandler.cs
+++ b/UmbracoVault/TypeHandlers/MediaTypeHandler.cs
@@ -27,6 +27,11 @@ namespace UmbracoVault.TypeHandlers
 
     	public object GetAsType<T>(object input)
 	    {
+	        if (input is IPublishedContent)
+	        {
+	            return input;
+	        }
+
 	        var mediaObject = Get(input?.ToString());
 	        if (mediaObject == null)
 	        {

--- a/UmbracoVault/TypeHandlers/UmbracoEntityTypeHandler.cs
+++ b/UmbracoVault/TypeHandlers/UmbracoEntityTypeHandler.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 
+using Umbraco.Core.Models;
+
 using UmbracoVault.Attributes;
 
 namespace UmbracoVault.TypeHandlers
@@ -11,6 +13,11 @@ namespace UmbracoVault.TypeHandlers
     {
         public object GetAsType<T>(object input)
         {
+            if (input is IPublishedContent)
+            {
+                return input;
+            }
+
             var content = Vault.Context.GetContentById<T>(input.ToString());
 
             return content;


### PR DESCRIPTION
Newer versions of Umbraco have value converters that result in the TypeHandlers receiving values that have already been converted to the desired type. This was breaking the Media and Entity type handlers that always assumed a string was being returned.

Added single check to return input if the input is already IPublishedContent